### PR TITLE
#165965091 : Modify loans endpoint to use filtering of current and repaid loans 

### DIFF
--- a/build/routes/loanRoute.js
+++ b/build/routes/loanRoute.js
@@ -21,7 +21,5 @@ route.get('/api/v1/loans/:id', _auth["default"], _LoanController["default"].spec
 route.patch('/api/v1/loans/:id', _auth["default"], _LoanController["default"].approveLoan);
 route.post('/api/v1/loans/:id/repayment', _auth["default"], _LoanController["default"].repayLoan);
 route.get('/api/v1/repayments/loans', _auth["default"], _LoanController["default"].allRepaymentLoan);
-route.get('/api/v1/loans/current/loans', _auth["default"], _LoanController["default"].currentLoan);
-route.get('/api/v1/loans/repaid/loans', _auth["default"], _LoanController["default"].repaidLoan);
 var _default = route;
 exports["default"] = _default;

--- a/build/tests/loans.test.js
+++ b/build/tests/loans.test.js
@@ -114,21 +114,27 @@ describe('Loan applications', function () {
       expect(res.body).to.have.property('message');
       expect(res.body).to.be.an('object');
     });
-  });
-  it('should not allowed to view all repaid loans', function () {
-    _chai["default"].request(_app["default"]).get('/api/v1/loans/repaid/loans').set('Authorization', token).end(function (err, res) {
-      expect(res.body.status).to.equal(400);
-      expect(res.body).to.have.property('status');
-      expect(res.body).to.be.an('object');
-    });
-  });
-  it('should not allowed to view all current loans', function () {
-    _chai["default"].request(_app["default"]).get('/api/v1/loans/current/loans').set('Authorization', token).end(function (err, res) {
-      expect(res.body.status).to.equal(400);
-      expect(res.body).to.have.property('status');
-      expect(res.body).to.be.an('object');
-    });
-  });
+  }); // it('should not allowed to view all repaid loans', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/repaid/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(400);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
+  // it('should not allowed to view all current loans', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/current/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(400);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
+
   it('should not allowed to repay a loans, only admin', function () {
     _chai["default"].request(_app["default"]).post('/api/v1/loans/1/repayment').set('Authorization', token).end(function (err, res) {
       expect(res.body.status).to.equal(400);
@@ -150,15 +156,18 @@ describe('Repayment loan', function () {
 
   var token = _jsonwebtoken["default"].sign(isAdmin, "".concat(process.env.SECRET_KEY_CODE), {
     expiresIn: '24h'
-  });
+  }); // it('should not return current repayment history becouse it is empty', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/current/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(404);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
 
-  it('should not return current repayment history becouse it is empty', function () {
-    _chai["default"].request(_app["default"]).get('/api/v1/loans/current/loans').set('Authorization', token).end(function (err, res) {
-      expect(res.body.status).to.equal(404);
-      expect(res.body).to.have.property('status');
-      expect(res.body).to.be.an('object');
-    });
-  });
+
   it('should not accept others status rather than approved or rejected', function () {
     _chai["default"].request(_app["default"]).patch('/api/v1/loans/1').set('Authorization', token).send({
       status: 'not-approved'
@@ -230,21 +239,27 @@ describe('Repayment loan', function () {
       expect(res.body).to.have.property('message');
       expect(res.body).to.be.an('object');
     });
-  });
-  it('should return all current repayment history', function () {
-    _chai["default"].request(_app["default"]).get('/api/v1/loans/current/loans').set('Authorization', token).end(function (err, res) {
-      expect(res.body.status).to.equal(200);
-      expect(res.body).to.have.property('status');
-      expect(res.body).to.be.an('object');
-    });
-  });
-  it('should not return repaid loans because not repaid yet', function () {
-    _chai["default"].request(_app["default"]).get('/api/v1/loans/repaid/loans').set('Authorization', token).end(function (err, res) {
-      expect(res.body.status).to.equal(404);
-      expect(res.body).to.have.property('status');
-      expect(res.body).to.be.an('object');
-    });
-  });
+  }); // it('should return all current repayment history', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/current/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(200);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
+  // it('should not return repaid loans because not repaid yet', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/repaid/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(404);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
+
   it('should create a repayment loan even if the amount are greater than responsibility ', function () {
     _chai["default"].request(_app["default"]).post('/api/v1/loans/1/repayment').set('Authorization', token).send({
       amount: '500000'
@@ -254,14 +269,17 @@ describe('Repayment loan', function () {
       expect(res.body).to.have.property('message');
       expect(res.body).to.be.an('object');
     });
-  });
-  it('should return all repaid loan(s)', function () {
-    _chai["default"].request(_app["default"]).get('/api/v1/loans/repaid/loans').set('Authorization', token).end(function (err, res) {
-      expect(res.body.status).to.equal(200);
-      expect(res.body).to.have.property('status');
-      expect(res.body).to.be.an('object');
-    });
-  });
+  }); // it('should return all repaid loan(s)', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/repaid/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(200);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
+
   it('should not repay loan because no loan you have', function () {
     _chai["default"].request(_app["default"]).post('/api/v1/loans/1/repayment').set('Authorization', token).send({
       amount: '500000'

--- a/server/routes/loanRoute.js
+++ b/server/routes/loanRoute.js
@@ -2,19 +2,12 @@ import express from 'express';
 import loanController from '../controllers/LoanController';
 import auth from '../middleware/auth';
 
-
 const route = express.Router();
 
-route.post('/api/v1/loans',auth, loanController.applyLoan);
-route.get('/api/v1/loans',auth, loanController.allLoans);
-route.get('/api/v1/loans/:id',auth, loanController.specificLoan);
-route.patch('/api/v1/loans/:id',auth, loanController.approveLoan);
-
-route.post('/api/v1/loans/:id/repayment',auth, loanController.repayLoan);
-route.get('/api/v1/repayments/loans',auth, loanController.allRepaymentLoan);
-
-route.get('/api/v1/loans/current/loans',auth, loanController.currentLoan);
-route.get('/api/v1/loans/repaid/loans',auth, loanController.repaidLoan);
-
-
+route.post('/api/v1/loans', auth, loanController.applyLoan);
+route.get('/api/v1/loans', auth, loanController.allLoans);
+route.get('/api/v1/loans/:id', auth, loanController.specificLoan);
+route.patch('/api/v1/loans/:id', auth, loanController.approveLoan);
+route.post('/api/v1/loans/:id/repayment', auth, loanController.repayLoan);
+route.get('/api/v1/repayments/loans', auth, loanController.allRepaymentLoan);
 export default route;

--- a/server/tests/loans.test.js
+++ b/server/tests/loans.test.js
@@ -135,27 +135,27 @@ describe('Loan applications', () => {
       });
   });
 
-  it('should not allowed to view all repaid loans', () => {
-    chai.request(server)
-      .get('/api/v1/loans/repaid/loans')
-      .set('Authorization', token)
-      .end((err, res) => {
-        expect(res.body.status).to.equal(400);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.be.an('object');
-      });
-  });
+  // it('should not allowed to view all repaid loans', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/repaid/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(400);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
 
-  it('should not allowed to view all current loans', () => {
-    chai.request(server)
-      .get('/api/v1/loans/current/loans')
-      .set('Authorization', token)
-      .end((err, res) => {
-        expect(res.body.status).to.equal(400);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.be.an('object');
-      });
-  });
+  // it('should not allowed to view all current loans', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/current/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(400);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
 
   it('should not allowed to repay a loans, only admin', () => {
     chai.request(server)
@@ -181,16 +181,16 @@ describe('Repayment loan', () => {
   }
   const token = jwt.sign(isAdmin, `${process.env.SECRET_KEY_CODE}`, { expiresIn: '24h' });
 
-  it('should not return current repayment history becouse it is empty', () => {
-    chai.request(server)
-      .get('/api/v1/loans/current/loans')
-      .set('Authorization', token)
-      .end((err, res) => {
-        expect(res.body.status).to.equal(404);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.be.an('object');
-      });
-  });
+  // it('should not return current repayment history becouse it is empty', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/current/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(404);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
 
   it('should not accept others status rather than approved or rejected', () => {
     chai.request(server)
@@ -303,27 +303,27 @@ describe('Repayment loan', () => {
       });
   });
 
-  it('should return all current repayment history', () => {
-    chai.request(server)
-      .get('/api/v1/loans/current/loans')
-      .set('Authorization', token)
-      .end((err, res) => {
-        expect(res.body.status).to.equal(200);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.be.an('object');
-      });
-  });
+  // it('should return all current repayment history', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/current/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(200);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
 
-  it('should not return repaid loans because not repaid yet', () => {
-    chai.request(server)
-      .get('/api/v1/loans/repaid/loans')
-      .set('Authorization', token)
-      .end((err, res) => {
-        expect(res.body.status).to.equal(404);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.be.an('object');
-      });
-  });
+  // it('should not return repaid loans because not repaid yet', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/repaid/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(404);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
 
   it('should create a repayment loan even if the amount are greater than responsibility ', () => {
     chai.request(server)
@@ -340,16 +340,16 @@ describe('Repayment loan', () => {
       });
   });
 
-  it('should return all repaid loan(s)', () => {
-    chai.request(server)
-      .get('/api/v1/loans/repaid/loans')
-      .set('Authorization', token)
-      .end((err, res) => {
-        expect(res.body.status).to.equal(200);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.be.an('object');
-      });
-  });
+  // it('should return all repaid loan(s)', () => {
+  //   chai.request(server)
+  //     .get('/api/v1/loans/repaid/loans')
+  //     .set('Authorization', token)
+  //     .end((err, res) => {
+  //       expect(res.body.status).to.equal(200);
+  //       expect(res.body).to.have.property('status');
+  //       expect(res.body).to.be.an('object');
+  //     });
+  // });
 
   it('should not repay loan because no loan you have', () => {
     chai.request(server)

--- a/swagger.json
+++ b/swagger.json
@@ -1,5 +1,5 @@
 {
-  "swagger": "2.0",
+    "swagger": "2.0",
   "info": {
     "description": "Quick Credit is an web lending platform that provides short term soft loans to individuals. This helps solve problems of financial inclusion as a way to alleviate poverty and empower low income earners",
     "version": "1",
@@ -35,7 +35,7 @@
         "tags": [
           "Authentication"
         ],
-        "summary": "Creating an account",
+        "summary": "Creating a user/client account",
         "parameters": [
           {
             "name": "user",
@@ -56,7 +56,33 @@
         }
       }
     },
-    "/auth/login": {
+    "/auth/signup'": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Creating an admin account",
+        "parameters": [
+          {
+            "name": "user",
+            "in": "body",
+            "description": "Admin create",
+            "schema": {
+              "$ref": "#/definitions/adminsignup"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Admin account Successfully registed ",
+            "schema": {
+              "$ref": "#/definitions/adminsignup"
+            }
+          }
+        }
+      }
+    },
+    "/auth/signin": {
       "post": {
         "tags": [
           "Authentication"
@@ -319,32 +345,6 @@
           "Loan Repayment"
         ],
         "summary": "Retriveing all loans repayment history.",
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
-    "/loans/current/loans": {
-      "get": {
-        "tags": [
-          "Loan Repayment"
-        ],
-        "summary": "Retreiving all current loans (status is approved and repaid is false)",
-        "responses": {
-          "200": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
-    "/loans/repaid/loans": {
-      "get": {
-        "tags": [
-          "Loan Repayment"
-        ],
-        "summary": "Retreiving all repaid loans ((status is approved and repaid is true))",
         "responses": {
           "200": {
             "description": "successful operation"


### PR DESCRIPTION
# PR description

#### What does this PR do?
This pull request helped an admin for organizing organize the loans API endpoints in single loans endpoint in order to view all loans, currents loans, and repaid loans endpoint.
#### Description of Task to be completed?
* Deleting the existing two API endpoints for loans filtering
* Recompile Quik credit  application
#### How should this be manually tested?
Clone or download the develop blanch to your local machine and navigate try to interact with APIs endpoints 
#### What are the relevant pivotal tracker stories?
PT-ID: #165965091
#### Any background context you want to add?
N/A